### PR TITLE
Serialize time to a string value

### DIFF
--- a/examples/neo4j-causal-graph/main.go
+++ b/examples/neo4j-causal-graph/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/chop-dbhi/eda"
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
@@ -58,7 +59,7 @@ func run() error {
 	flag.StringVar(&addr, "addr", "nats://localhost:4222", "NATS address")
 	flag.StringVar(&cluster, "cluster", "test-cluster", "NATS cluster name.")
 	flag.StringVar(&client, "client", "neo4j-causal-graph", "Client connection ID.")
-	flag.StringVar(&stream, "stream", "test", "Stream name.")
+	flag.StringVar(&stream, "stream", "events", "Stream name.")
 	flag.StringVar(&neo4jBolt, "neo4j.bolt", "bolt://localhost:7687", "Neo4j bolt address.")
 
 	flag.Parse()
@@ -81,7 +82,7 @@ func run() error {
 		_, err = neoConn.ExecNeo(createNode, map[string]interface{}{
 			"id":       evt.ID,
 			"type":     evt.Type,
-			"time":     evt.Time,
+			"time":     evt.Time.Format(time.RFC3339Nano),
 			"client":   evt.Client,
 			"encoding": evt.Data.Type(),
 		})


### PR DESCRIPTION
This commit has two changes:

1. It changes the subscriction stream to `events` just like the clock
example uses.
2. It serializes time values to strings as Neo4J does not has a native
time datatype.

The choice to serialize to string is arbritary as time could also
serialize to a long value. But I found this to be more readable as this
code is for example purposes.

Using the example resulted into an error for me:

```
Unrecognized type when encoding data for Bolt transport: time.Time 
```